### PR TITLE
Change --force to --force-with-lease

### DIFF
--- a/git-teach.html
+++ b/git-teach.html
@@ -378,7 +378,7 @@ https://www.atlassian.com/git/tutorials/merging-vs-rebasing
 * `git rebase --continue`
 * `git rebase --skip`
 * `git rebase --abort`
-* **Remember to do** `git push --force` after rebase
+* **Remember to do** `git push --force-with-lease` after rebase
 
 * Rebase order matters. UK-114 -> UK->113 -> UK->82 -> Release Candidate
 


### PR DESCRIPTION
Along working with current projects I have found out that plain --force might be disruptive.

Using the --force-with-lease as plain --force unconditionally
overrides any changes that do not match in the two branches.

https://stackoverflow.com/questions/52823692/git-push-force-with-lease-vs-force